### PR TITLE
Remove Cloudgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Let's make OSS a better place by incentivizing people to work on it. If you know
 
 | Name | Description | Link | Tech Used |  Details | Payment | Getting Started |
 | ---- | ----------- | ---- | --------- | -------- | ------- |  -------------- |
-| CloudGraph | The GraphQL API for everything | https://github.com/cloudgraphdev/cli | Dgraph, TypeScript, GraphQL | Help the CloudGraph OSS team build out data providers for Digital Ocean, GitHub and others | $1,000 USD for each provider with 10 initial services | https://github.com/cloudgraphdev/cli/blob/master/CONTRIBUTING.md |
 | RudderStack |  open source Customer Data Platform (CDP) | https://github.com/rudderlabs/rudder-server| GO, TypeScript | Misc issues and bounties | $2,000 USD per bounty | https://dev.to/rudderstack/devs-wanted-get-paid-to-contribute-to-rudderstack-s-open-source-software-bjp |
 | openScale |  Open-source weight and body metrics tracker | https://github.com/oliexdev/openScale| Java, C++ | Support Scale connection through MQTT | $30 USD  | https://www.bountysource.com/issues/103484231-feature-request-support-scale-connection-through-mqtt |
 | Etherpad |  Online collaborative really real-time editor | https://github.com/ether/etherpad-lite| Javascript | Misc issues and bounties | $80 USD | https://github.com/ether/etherpad-lite/issues |


### PR DESCRIPTION
"Updating CONTRIBUTING guide as our needs for providers have changed from two years ago."

https://github.com/cloudgraphdev/cli/commit/7f460b535faf9e9c2dbb72a944719d58e24910b7